### PR TITLE
Allow footer to expand vertically to accommodate copious html tags

### DIFF
--- a/skins/drip/elementspath.css
+++ b/skins/drip/elementspath.css
@@ -23,7 +23,8 @@ The following is a visual representation of its main elements:
 .cke_path
 {
 	float: left;
-	height: 18px;
+	min-height: 18px;
+  max-width: calc(100% - 100px);
 }
 
 /* Each item of the elements path. */
@@ -71,6 +72,7 @@ a.cke_path_item:active
   float: right;
 	color: #05132B;
   margin: 0 6px;
+  max-width: 72px;
 }
 
 

--- a/skins/drip/mainui.css
+++ b/skins/drip/mainui.css
@@ -116,7 +116,7 @@ Special outer level classes used in this file:
 .cke_bottom
 {
 	padding: 3px 12px;
-  height: 24px;
+  min-height: 24px;
   border-radius: 0 0 3px 3px;
 	position: relative;
 	background: #D3D9E4;


### PR DESCRIPTION
Fixes https://github.com/DripEmail/drip/issues/5826

Allow copious html tags to expand height of CKEditor