### PR TITLE
Wrap link text in <span>

### DIFF
--- a/plugins/driplink/plugin.js
+++ b/plugins/driplink/plugin.js
@@ -180,6 +180,11 @@
 						range.selectNodeContents( text );
 					}
 
+					var wrapper = new CKEDITOR.style( {
+						element: 'span'
+					} );
+					wrapper.applyToRange( range, editor );
+
 					// Apply style.
 					var style = new CKEDITOR.style( {
 						element: 'a',


### PR DESCRIPTION
Required by https://github.com/DripEmail/drip/pull/5987

Any links inserted with `driplink` get their contents wrapped in a `<span>`.