### PR TITLE
Force line-height of 1 on dropdown contents

### DIFF
--- a/skins/drip/panel.css
+++ b/skins/drip/panel.css
@@ -189,7 +189,7 @@ is its visual representation:
 }
 
 .cke_panel_listItem a span {
-  line-height: 1;
+  line-height: 1 !important;
 }
 
 .cke_panel_listItem.cke_selected a


### PR DESCRIPTION
CKEditor inlines each dropdown items' style, which makes the dropdown
look bad. '8px' entry gets `line-height: 8px`; '72px' gets `line-height:
72px`. Didn't find a way to disable this in JS, so here's a single bit
of CSS.
