### PR TITLE
SA-31: Disable grammarly in the CKEditor.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,6 @@ tests/plugins/mathjax/_assets/mathjax/**
 *.css.map
 
 bender-*.log
+
+.DS_Store
+npm-debug.log

--- a/core/creators/inline.js
+++ b/core/creators/inline.js
@@ -45,7 +45,7 @@
 
 			//Change element from textarea to div
 			element = CKEDITOR.dom.element.createFromHtml(
-				'<div contenteditable="' + !!editor.readOnly + '" class="cke_textarea_inline">' +
+				'<div contenteditable="' + !!editor.readOnly + '" class="cke_textarea_inline" data-gramm="false" data-gramm_editor="false">' +
 					textarea.getValue() +
 				'</div>',
 				CKEDITOR.document );


### PR DESCRIPTION
The Grammarly plugin has been a thorn in the side of CKEditor/Elm. Turns out there's a data attribute that it respects (at least for now).

I could not find any official documentation, but there is this [stack overflow answer](https://stackoverflow.com/a/46777787/55223). Look in the comments for the "new" way to disable it.