### PR TITLE
Updating the CSS for the Color Panel

### DIFF
--- a/skins/drip/colorpanel.css
+++ b/skins/drip/colorpanel.css
@@ -51,7 +51,7 @@ The COLOR PALETTE section instead is a table with a variable number of cells
 .cke_colorblock
 {
 	padding: 3px;
-	font-size: 11px;
+	font-size: 14px;
 	font-family: 'Microsoft Sans Serif', Tahoma, Arial, Verdana, Sans-Serif;
 }
 
@@ -66,8 +66,9 @@ The COLOR PALETTE section instead is a table with a variable number of cells
    It is a small, square-shaped element which can be selected from the palette. */
 span.cke_colorbox
 {
-	width: 10px;
-	height: 10px;
+	width: 20px;
+	height: 20px;
+	margin-left:1px;
 	border: #808080 1px solid;
 	float: left;
 }
@@ -81,10 +82,10 @@ span.cke_colorbox
 a.cke_colorbox
 {
 	border: #fff 1px solid;
-	padding: 2px;
+	padding-top: 1px;
 	float: left;
-	width: 12px;
-	height: 12px;
+	width: 24px;
+	height: 24px;
 }
 
 .cke_rtl a.cke_colorbox


### PR DESCRIPTION
https://github.com/DripEmail/drip/pull/21077 Relevant Monolith PR

We wanted to replace the whole picker but settled for some usability and css updates instead

ORIGINAL
<img width="712" alt="Screen Shot 2021-05-10 at 11 25 04 AM" src="https://user-images.githubusercontent.com/79865974/117697584-3d79e780-b188-11eb-951e-17cbc3d82b9a.png">


UPDATED 
<img width="650" alt="Screen Shot 2021-05-10 at 11 54 21 AM" src="https://user-images.githubusercontent.com/79865974/117697607-44085f00-b188-11eb-924f-772f6c2908c6.png">
![Uploading Screen Shot 2021-05-10 at 12.00.23 PM.png…]()
